### PR TITLE
Fix the missing \'<<Go Back\' when the /pages/PokemonDetailsPage.jsx …

### DIFF
--- a/components/GoBack.jsx
+++ b/components/GoBack.jsx
@@ -5,8 +5,12 @@ import styled from 'styled-components'
 const Link = styled(NavLink)`
   color: white;
   font-size: 20px;
+  position: fixed;
   text-align: left;
   text-decoration: none;
+  top: 100px;
+  left: 30px;
+  z-index: 10;
 
   &:hover {
     color: magenta;


### PR DESCRIPTION
…is rendered.